### PR TITLE
Fixing the unit tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
   grunt.initConfig({
     env: {
       test: {
-        SONGS_DIR: 'test/songs'
+        SONGS_DIR: '../test/songs'
       }
     },
     nodeunit: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs'),
     path = require('path'),
-    songsDir = process.env.SONGS_DIR || path.join(__dirname, 'songs');
+    songsDir = path.join(__dirname, process.env.SONGS_DIR || 'songs');
 
 var songs = exports;
 


### PR DESCRIPTION
There is a disconnect when overriding the `songsDir` for test in that `require` uses a different cwd path than `fs.readdir`.  By explicitly calling out the folder in test (just like in runtime), both resolutions are happy and the tests are green.
